### PR TITLE
feat: add ignition confirmation and serial logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ npm run typecheck    # TypeScript 타입 검사
 
 - 명령 전송 형식: `드라이버번호,채널번호,명령` 예) `1,0,O` (1번 드라이버 0번 채널 밸브 열기)
 - 수신 데이터는 `key:value` 쌍을 콤마로 구분한 문자열로 가정합니다.
-- 밸브와 모터의 매핑은 `page.tsx`의 `valveToMotorMapping` 객체에서 정의합니다.
+- 밸브와 모터의 매핑은 프로젝트 루트의 `config.json` 파일에서 정의합니다.
 
 ## 스타일 가이드
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,14 @@
+{
+  "serial": {
+    "baudRate": 115200
+  },
+  "valveToMotorMapping": {
+    "Ethanol Main": { "driver": 1, "channel": 0 },
+    "N2O Main": { "driver": 1, "channel": 1 },
+    "Ethanol Purge": { "driver": 1, "channel": 2 },
+    "N2O Purge": { "driver": 1, "channel": 3 },
+    "Pressurant Fill": { "driver": 2, "channel": 0 },
+    "System Vent": { "driver": 2, "channel": 1 },
+    "Igniter Fuel": { "driver": 2, "channel": 2 }
+  }
+}

--- a/main.js
+++ b/main.js
@@ -1,10 +1,13 @@
 const { app, BrowserWindow, ipcMain } = require('electron');
 const path = require('path');
+const fs = require('fs');
 const isDev = require('electron-is-dev');
 const { SerialPort } = require('serialport');
 
 let mainWindow;
 let port;
+let logStream;
+let appConfig;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -30,7 +33,16 @@ function createWindow() {
   mainWindow.on('closed', () => (mainWindow = null));
 }
 
-app.on('ready', createWindow);
+app.whenReady().then(() => {
+  const configPath = path.join(__dirname, 'config.json');
+  try {
+    appConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  } catch (err) {
+    console.error('Failed to load config:', err);
+    appConfig = {};
+  }
+  createWindow();
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
@@ -65,6 +77,23 @@ ipcMain.on('zoom-reset', () => {
   }
 });
 
+ipcMain.handle('get-config', () => appConfig);
+
+ipcMain.on('start-logging', () => {
+  const timestamp = new Date();
+  const fileName = `rocket-log-${timestamp.getFullYear()}${String(timestamp.getMonth() + 1).padStart(2, '0')}${String(timestamp.getDate()).padStart(2, '0')}-${String(timestamp.getHours()).padStart(2, '0')}${String(timestamp.getMinutes()).padStart(2, '0')}${String(timestamp.getSeconds()).padStart(2, '0')}.csv`;
+  const filePath = path.join(__dirname, fileName);
+  logStream = fs.createWriteStream(filePath, { flags: 'w' });
+  logStream.write('timestamp,pt1,pt2,pt3,pt4,flow1,flow2,tc1\n');
+});
+
+ipcMain.on('stop-logging', () => {
+  if (logStream) {
+    logStream.end();
+    logStream = null;
+  }
+});
+
 // --- 시리얼 통신 관련 코드 ---
 
 // 사용 가능한 시리얼 포트 목록을 UI에 전송
@@ -85,9 +114,11 @@ ipcMain.handle('connect-serial', async (event, portName) => {
   if (port && port.isOpen) {
     await new Promise(resolve => port.close(resolve));
   }
-  
+
+  const baudRate = appConfig?.serial?.baudRate || 9600;
+
   return new Promise((resolve) => {
-    port = new SerialPort({ path: portName, baudRate: 9600 }, (err) => {
+    port = new SerialPort({ path: portName, baudRate }, (err) => {
       if (err) {
         console.error('Failed to open port:', err);
         resolve(false);
@@ -98,7 +129,22 @@ ipcMain.handle('connect-serial', async (event, portName) => {
       console.log(`Serial port ${portName} opened`);
       
       port.on('data', (data) => {
-        mainWindow.webContents.send('serial-data', data.toString());
+        const str = data.toString();
+        mainWindow.webContents.send('serial-data', str);
+
+        if (logStream) {
+          const parts = str.split(',');
+          const parsed = {};
+          parts.forEach(part => {
+            const [key, value] = part.split(':');
+            if (key && value) {
+              parsed[key.trim()] = value.trim();
+            }
+          });
+          const fields = ['pt1','pt2','pt3','pt4','flow1','flow2','tc1'];
+          const line = `${Date.now()},${fields.map(f => parsed[f] || '').join(',')}\n`;
+          logStream.write(line);
+        }
       });
 
       port.on('error', (err) => {

--- a/preload.js
+++ b/preload.js
@@ -11,4 +11,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   zoomIn: () => ipcRenderer.send('zoom-in'),
   zoomOut: () => ipcRenderer.send('zoom-out'),
   zoomReset: () => ipcRenderer.send('zoom-reset'),
+  startLogging: () => ipcRenderer.send('start-logging'),
+  stopLogging: () => ipcRenderer.send('stop-logging'),
+  getConfig: () => ipcRenderer.invoke('get-config'),
 });

--- a/src/components/dashboard/header.tsx
+++ b/src/components/dashboard/header.tsx
@@ -9,14 +9,18 @@ interface HeaderProps {
   selectedPort: string;
   onPortChange: (port: string) => void;
   onConnect: () => void;
+  isLogging: boolean;
+  onToggleLogging: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ 
-  connectionStatus, 
-  ports, 
-  selectedPort, 
-  onPortChange, 
-  onConnect 
+const Header: React.FC<HeaderProps> = ({
+  connectionStatus,
+  ports,
+  selectedPort,
+  onPortChange,
+  onConnect,
+  isLogging,
+  onToggleLogging
 }) => {
   const isConnected = connectionStatus === 'connected';
   const isConnecting = connectionStatus === 'connecting';
@@ -48,6 +52,9 @@ const Header: React.FC<HeaderProps> = ({
 
         <Button onClick={onConnect} disabled={isConnecting || (!selectedPort && !isConnected)} variant={isConnected ? "destructive" : "default"}>
           {isConnecting ? "Connecting..." : (isConnected ? "Disconnect" : "Connect")}
+        </Button>
+        <Button onClick={onToggleLogging} variant={isLogging ? "destructive" : "secondary"}>
+          {isLogging ? "Stop Logging" : "Start Logging"}
         </Button>
 
         <div className="flex items-center gap-2">

--- a/src/components/dashboard/sequence-panel.tsx
+++ b/src/components/dashboard/sequence-panel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
 import { PlayCircle, ShieldAlert, Zap, Wind } from 'lucide-react';
 
 interface SequencePanelProps {
@@ -23,16 +24,41 @@ const SequencePanel: React.FC<SequencePanelProps> = ({ onSequence, activeSequenc
         </CardHeader>
         <CardContent className="flex flex-col gap-3">
             {sequences.map(seq => (
-                <Button 
-                    key={seq.name} 
-                    variant={seq.variant} 
-                    className="w-full justify-start text-base py-6" 
-                    onClick={() => onSequence(seq.name)}
-                    disabled={!!activeSequence}
-                >
-                    {React.cloneElement(seq.icon, { className: 'w-5 h-5 mr-3' })}
-                    {seq.name}
-                </Button>
+                seq.name === "Ignition Sequence" ? (
+                    <AlertDialog key={seq.name}>
+                        <AlertDialogTrigger asChild>
+                            <Button
+                                variant={seq.variant}
+                                className="w-full justify-start text-base py-6"
+                                disabled={!!activeSequence}
+                            >
+                                {React.cloneElement(seq.icon, { className: 'w-5 h-5 mr-3' })}
+                                {seq.name}
+                            </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                            <AlertDialogTitle>경고: 점화 시퀀스</AlertDialogTitle>
+                            <AlertDialogDescription>
+                                점화 시퀀스를 시작하시겠습니까? 이 동작은 되돌릴 수 없습니다.
+                            </AlertDialogDescription>
+                            <AlertDialogFooter>
+                                <AlertDialogCancel>취소</AlertDialogCancel>
+                                <AlertDialogAction onClick={() => onSequence(seq.name)}>점화 시작</AlertDialogAction>
+                            </AlertDialogFooter>
+                        </AlertDialogContent>
+                    </AlertDialog>
+                ) : (
+                    <Button
+                        key={seq.name}
+                        variant={seq.variant}
+                        className="w-full justify-start text-base py-6"
+                        onClick={() => onSequence(seq.name)}
+                        disabled={!!activeSequence}
+                    >
+                        {React.cloneElement(seq.icon, { className: 'w-5 h-5 mr-3' })}
+                        {seq.name}
+                    </Button>
+                )
             ))}
         </CardContent>
     </Card>

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -11,6 +11,12 @@ declare global {
       onSerialData: (callback: (data: string) => void) => void;
       onSerialError: (callback: (error: string) => void) => void;
       removeAllListeners: (channel: string) => void;
+      zoomIn: () => void;
+      zoomOut: () => void;
+      zoomReset: () => void;
+      startLogging: () => void;
+      stopLogging: () => void;
+      getConfig: () => Promise<import('./index').AppConfig>;
     };
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,11 @@
+export interface ValveMappingEntry {
+  driver: number;
+  channel: number;
+}
+
+export interface AppConfig {
+  serial: {
+    baudRate: number;
+  };
+  valveToMotorMapping: Record<string, ValveMappingEntry>;
+}


### PR DESCRIPTION
## Summary
- confirm ignition sequence with alert dialog
- stream incoming serial data to timestamped CSV logs
- load hardware mapping and baud rate from config file

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(terminated: Next.js ESLint plugin warning)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6891a81b50ec832fa68399c469511a29