### PR TITLE
feat: validate serial commands

### DIFF
--- a/main.js
+++ b/main.js
@@ -170,6 +170,12 @@ ipcMain.handle('disconnect-serial', async () => {
 });
 
 ipcMain.on('send-to-serial', (event, data) => {
+  // Validate command format before sending to serial port
+  const isValid = /^(\d+),(\d+),(O|C)$/.test(data);
+  if (!isValid) {
+    console.error('Invalid command format received:', data);
+    return;
+  }
   if (port && port.isOpen) {
     port.write(data + '\n', (err) => {
       if (err) {


### PR DESCRIPTION
## Summary
- add regex-based validation for serial commands before writing to hardware

## Testing
- `npm test` *(fails: Missing script: "test" [npm error])* 
- `npm run lint` *(fails: Next.js ESLint configuration prompt)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6891cdd307c0832f80280e2ad09dd620