### PR TITLE
chore: remove removeAllListeners API

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -7,7 +7,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   sendToSerial: (data) => ipcRenderer.send('send-to-serial', data),
   onSerialData: (callback) => ipcRenderer.on('serial-data', (_event, value) => callback(value)),
   onSerialError: (callback) => ipcRenderer.on('serial-error', (_event, value) => callback(value)),
-  removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel),
   zoomIn: () => ipcRenderer.send('zoom-in'),
   zoomOut: () => ipcRenderer.send('zoom-out'),
   zoomReset: () => ipcRenderer.send('zoom-reset'),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -213,8 +213,6 @@ export default function Home() {
     window.electronAPI.onSerialError(handleSerialError);
 
     return () => {
-      window.electronAPI.removeAllListeners('serial-data');
-      window.electronAPI.removeAllListeners('serial-error');
       sequenceTimeoutRef.current.forEach(clearTimeout);
     };
   }, [sensorData]);

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -10,7 +10,6 @@ declare global {
       sendToSerial: (data: string) => void;
       onSerialData: (callback: (data: string) => void) => void;
       onSerialError: (callback: (error: string) => void) => void;
-      removeAllListeners: (channel: string) => void;
       zoomIn: () => void;
       zoomOut: () => void;
       zoomReset: () => void;


### PR DESCRIPTION
## Summary
- remove dangerous `removeAllListeners` API exposure
- drop corresponding type definition and usage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6891cded63e8832fad7256a2900f3546