### PR TITLE
Handle log file creation failures

### DIFF
--- a/main.js
+++ b/main.js
@@ -86,6 +86,10 @@ ipcMain.on('start-logging', () => {
   // 올바른 경로로 수정된 최종 버전입니다.
   const filePath = path.join(app.getPath('documents'), fileName);
   logStream = fs.createWriteStream(filePath, { flags: 'w' });
+  logStream.on('error', (err) => {
+    console.error('Failed to create log file:', err);
+    mainWindow?.webContents.send('log-creation-failed', err.message);
+  });
   logStream.write('timestamp,pt1,pt2,pt3,pt4,flow1,flow2,tc1\n');
 });
 

--- a/preload.js
+++ b/preload.js
@@ -13,4 +13,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   startLogging: () => ipcRenderer.send('start-logging'),
   stopLogging: () => ipcRenderer.send('stop-logging'),
   getConfig: () => ipcRenderer.invoke('get-config'),
+  onLogCreationFailed: (callback) => ipcRenderer.on('log-creation-failed', (_event, value) => callback(value)),
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -217,6 +217,12 @@ export default function Home() {
     };
   }, [sensorData]);
 
+  useEffect(() => {
+    window.electronAPI.onLogCreationFailed(() => {
+      toast({ title: "Logging Error", description: "Failed to create log file.", variant: "destructive" });
+    });
+  }, [toast]);
+
   const handleConnect = async () => {
     if (connectionStatus === 'connected') {
       await window.electronAPI.disconnectSerial();

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -16,6 +16,7 @@ declare global {
       startLogging: () => void;
       stopLogging: () => void;
       getConfig: () => Promise<import('./index').AppConfig>;
+      onLogCreationFailed: (callback: (error: string) => void) => void;
     };
   }
 }


### PR DESCRIPTION
## Summary
- handle errors during log file creation using 'error' event listener and notify renderer
- expose `onLogCreationFailed` to preload and global types
- show toast when log file creation fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6891d0af1074832f882955ad3675c0b4