### PR TITLE
Fix serial listener cleanup to prevent memory leaks

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -5,8 +5,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
   connectSerial: (portName) => ipcRenderer.invoke('connect-serial', portName),
   disconnectSerial: () => ipcRenderer.invoke('disconnect-serial'),
   sendToSerial: (data) => ipcRenderer.send('send-to-serial', data),
-  onSerialData: (callback) => ipcRenderer.on('serial-data', (_event, value) => callback(value)),
-  onSerialError: (callback) => ipcRenderer.on('serial-error', (_event, value) => callback(value)),
+  onSerialData: (callback) => {
+    const listener = (_event, value) => callback(value);
+    ipcRenderer.on('serial-data', listener);
+    return () => ipcRenderer.removeListener('serial-data', listener);
+  },
+  onSerialError: (callback) => {
+    const listener = (_event, value) => callback(value);
+    ipcRenderer.on('serial-error', listener);
+    return () => ipcRenderer.removeListener('serial-error', listener);
+  },
   zoomIn: () => ipcRenderer.send('zoom-in'),
   zoomOut: () => ipcRenderer.send('zoom-out'),
   zoomReset: () => ipcRenderer.send('zoom-reset'),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -209,10 +209,12 @@ export default function Home() {
         setConnectionStatus('disconnected');
     };
 
-    window.electronAPI.onSerialData(handleSerialData);
-    window.electronAPI.onSerialError(handleSerialError);
+    const cleanupSerialData = window.electronAPI.onSerialData(handleSerialData);
+    const cleanupSerialError = window.electronAPI.onSerialError(handleSerialError);
 
     return () => {
+      cleanupSerialData();
+      cleanupSerialError();
       sequenceTimeoutRef.current.forEach(clearTimeout);
     };
   }, [sensorData]);

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -8,8 +8,8 @@ declare global {
       connectSerial: (portName: string) => Promise<boolean>;
       disconnectSerial: () => Promise<boolean>;
       sendToSerial: (data: string) => void;
-      onSerialData: (callback: (data: string) => void) => void;
-      onSerialError: (callback: (error: string) => void) => void;
+      onSerialData: (callback: (data: string) => void) => () => void;
+      onSerialError: (callback: (error: string) => void) => () => void;
       zoomIn: () => void;
       zoomOut: () => void;
       zoomReset: () => void;


### PR DESCRIPTION
## Summary
- add cleanup callbacks to serial data and error listeners in preload
- expose cleanup returns in electron API types
- use cleanup functions in app component to unsubscribe from listeners

## Testing
- `npm test` *(fails: Missing script "test" `npm error Missing script: "test"`)*
- `npm run lint` *(fails: Next.js ESLint plugin setup prompt)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6891df356388832fb0cb5f6138a3639e